### PR TITLE
Add chmod +x to the readme file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ You can find the latest phar on the [releases page](https://github.com/bit3/fake
 
 ```bash
 $ wget https://github.com/bit3/faker-cli/releases/download/1.4/faker.phar
+chmod +x ./faker.phar
 $ ./faker.phar
 ```
 


### PR DESCRIPTION
Executing ./faker.phar did not work for me. I had to use `chmod +x`. Adding this to the readme would make it easier for people to get started with faker.phar.